### PR TITLE
fix(logger): mirror per-request JSON logs to stdout for docker compose logs

### DIFF
--- a/logger/logs.go
+++ b/logger/logs.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"io"
 	"os"
 	"runtime"
 	"strings"
@@ -20,7 +21,9 @@ func NewJSONFileLogger(filePath string) (*JSONFileLogger, error) {
 	}
 
 	logger := logrus.New()
-	logger.SetOutput(file)
+	// เขียนทั้งไฟล์และ stdout — เดิมเขียนแค่ไฟล์ ทำให้ `docker compose logs`
+	// (อ่านได้แค่ stdout/stderr ของ container) ไม่เห็น log ของทุก request เลย
+	logger.SetOutput(io.MultiWriter(file, os.Stdout))
 	logger.SetFormatter(&logrus.JSONFormatter{})
 
 	return &JSONFileLogger{log: logger}, nil


### PR DESCRIPTION
## ทำอะไร

ค้นพบระหว่างช่วยวินิจฉัย Google login 401 ที่ ru-connext-app: `docker compose logs` ไม่แสดง log ตอนเรียก API เลย

**สาเหตุ**: `ErrorLogger` (`logger/logs.go`, ใช้เป็น global middleware ใน `routers/routers.go:44-49` ผ่าน `NewJSONFileLogger("/logger/app.log")`) log ทุก request (status/method/path + error) ลง**ไฟล์เดียว**เท่านั้น — `docker compose logs` อ่านได้แค่ stdout/stderr ของ container จึงไม่เห็น log ชุดนี้เลย ทั้งที่ไฟล์ `/logger/app.log` มีข้อมูลอยู่จริง (mount ไว้ที่ `./logger` ใน docker-compose.yml)

**แก้**: เปลี่ยน output ของ logger เป็นเขียนทั้งไฟล์และ stdout พร้อมกันด้วย `io.MultiWriter` — จุดเดียว บรรทัดเดียว ไม่กระทบ log format หรือพฤติกรรมอื่น

## ทดสอบอย่างไร

- `go build ./logger/...` และ `go vet ./logger/...` ผ่าน (เครื่องนี้ไม่มี Oracle Instant Client/CGO เลย build เต็ม `./...` ไม่ได้ — ให้ CI/reviewer ยืนยันซ้ำ)
- diff แคบมาก (4 บรรทัดเพิ่ม, ลบ 1) ไม่แตะ logic อื่น
- แนะนำทดสอบจริง: deploy แล้วยิง request เข้า API สักครั้ง เช็คว่า `docker compose logs` เห็น JSON log บรรทัด "Request completed." ปรากฏ พร้อมกับที่ `/logger/app.log` ยังมีข้อมูลเหมือนเดิม

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQFCFunyRN1JrQmbtE9HXE